### PR TITLE
Fix some tests in Travis

### DIFF
--- a/tests/acceptance/grants/index-test.js
+++ b/tests/acceptance/grants/index-test.js
@@ -65,7 +65,7 @@ module('Acceptance | grants/index', (hooks) => {
         switch (index) {
           case 0:
           case 2:
-          case 5: {
+          case 4: {
             const html = td.querySelector('a');
             assert.ok(html, 'Cell must contain an Anchor tag');
             assert.ok(html.href, 'Cell must have an href');

--- a/tests/integration/components/grant-action-cell-test.js
+++ b/tests/integration/components/grant-action-cell-test.js
@@ -5,20 +5,16 @@ moduleForComponent('grant-action-cell', 'Integration | Component | grant action 
   integration: true
 });
 
-test('it renders', function(assert) {
+test('it renders', function (assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
   this.render(hbs`{{grant-action-cell}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(this.$().text().trim(), 'New Submission');
 
   // Template block usage:
-  this.render(hbs`
-    {{#grant-action-cell}}
-      template block text
-    {{/grant-action-cell}}
-  `);
+  this.render(hbs`{{#grant-action-cell}}template block text{{/grant-action-cell}}`);
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(this.$().text().trim(), 'New Submission\ntemplate block text');
 });

--- a/tests/unit/controllers/thanks-test.js
+++ b/tests/unit/controllers/thanks-test.js
@@ -6,7 +6,7 @@ moduleFor('controller:thanks', 'Unit | Controller | thanks', {
 });
 
 // Replace this with your real tests.
-test('it exists', function(assert) {
+test('it exists', function (assert) {
   let controller = this.subject();
   assert.ok(controller);
 });


### PR DESCRIPTION
One notable exception: most acceptance tests will fail when running `pass/tests` in a browser using the new Docker setup. They only fail when you run tests on a fresh environment! If you either manually login to the site, or have already run tests, the acceptance tests will pass because all relevant data has already been indexed correctly.

These acceptance tests need to wait for the indexer to finish indexing the test data before proceeding. The original mechanism I put in to do this used the Elasticsearch `_stats` API. However, I think the PASS proxy does not allow this request through, as it has a ProxyPass setup for `_search` only. I think this is causing the tests to timeout.

Modifying the `wait` code to do a general search for all objects will wait until all test objects are created. However, due to the naive way the test data is being set, the objects are created and saved first, before any relationships are set between them. Once all data objects are created and indexed (sans relationships), the test search will return with the total number of objects, but any queries issued from the UI at this point will return with incorrect data, as the relationships have not yet been set in Fedora, or indexed.

Since running tests this way will only be done manually by developers, we can live with it. Travis will not encounter this issue, since it will use the original Docker setup for automated tests.